### PR TITLE
Fix override of existing skin projectiles.

### DIFF
--- a/HenryMod/Content/HANDSurvivor/HANDSurvivor.cs
+++ b/HenryMod/Content/HANDSurvivor/HANDSurvivor.cs
@@ -462,14 +462,11 @@ namespace HANDMod.Content.HANDSurvivor
 
                 if (DoesSkinHaveDroneReplacement(skin))
                 {
-                    skin.projectileGhostReplacements = new SkinDef.ProjectileGhostReplacement[]
+                    HG.ArrayUtils.ArrayAppend(ref skin.projectileGhostReplacements,new SkinDef.ProjectileGhostReplacement
                     {
-                        new SkinDef.ProjectileGhostReplacement
-                        {
                             projectilePrefab = EntityStates.HAND_Overclocked.Special.FireSeekingDrone.projectilePrefab,
                             projectileGhostReplacementPrefab = CreateProjectileGhostReplacementPrefab(skin),
-                        }
-                    };
+                    });
                 }
             }
 


### PR DESCRIPTION
The current behavior discards any projectileGhostReplacements the skin originally possessed.
This changes it so that the drone ghost replacement is appended to the end instead